### PR TITLE
feat: add KSQL server, resolves #43

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,4 +25,4 @@ script:
 - ./test.sh zk-multiple-kafka-single.yml 4
 - ./test.sh zk-single-kafka-multiple.yml 4
 - ./test.sh zk-multiple-kafka-multiple.yml 6
-- ./test.sh full-stack.yml 10
+- ./test.sh full-stack.yml 11

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This replicates as well as possible real deployment configurations, where you ha
   - Kafka Topics UI: 0.9.4
   - Kafka Connect: Confluent 5.1.0
   - Kafka Connect UI: 0.9.4
+  - KSQL Server: Confluent 5.1.0
   - Zoonavigator: 0.5.1
 
 # Requirements
@@ -104,6 +105,7 @@ docker-compose -f zk-multiple-kafka-multiple.yml down
  - Kafka Topics UI: `$DOCKER_HOST_IP:8000`
  - Kafka Connect: `$DOCKER_HOST_IP:8083`
  - Kafka Connect UI: `$DOCKER_HOST_IP:8003`
+ - KSQL Server: `$DOCKER_HOST_IP:8088`
  - Zoonavigator Web: `$DOCKER_HOST_IP:8004`
 
 

--- a/full-stack.yml
+++ b/full-stack.yml
@@ -132,6 +132,19 @@ services:
     depends_on:
       - kafka-connect
 
+  ksql-server:
+    image: confluentinc/cp-ksql-server:5.1.0
+    hostname: ksql-server
+    ports:
+      - "8088:8088"
+    environment:
+      KSQL_BOOTSTRAP_SERVERS: PLAINTEXT://kafka1:19092
+      KSQL_LISTENERS: http://0.0.0.0:8088/
+      KSQL_KSQL_SERVICE_ID: ksql-server_
+    depends_on:
+      - zoo1
+      - kafka1
+
   zoonavigator-web:
     image: elkozmon/zoonavigator-web:0.5.1
     ports:


### PR DESCRIPTION
Adds a KSQL server to the `full-stack.yml`. It exposes port `8088`, the default KSQL port. You can access it utilizing the ksql CLI by typing `ksql` in a terminal. Resolves issue #43. 😄 