### PR TITLE
upgrade: bump kafka to 2.2.1 and confluent to 5.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@ This replicates as well as possible real deployment configurations, where you ha
 ## Stack version
 
   - Zookeeper version: 3.4.9
-  - Kafka version: 2.2.0 (Confluent 5.2.1)
-  - Kafka Schema Registry: Confluent 5.2.1
+  - Kafka version: 2.2.0 (Confluent 5.2.2)
+  - Kafka Schema Registry: Confluent 5.2.2
   - Kafka Schema Registry UI: 0.9.4
-  - Kafka Rest Proxy: Confluent 5.2.1
+  - Kafka Rest Proxy: Confluent 5.2.2
   - Kafka Topics UI: 0.9.4
-  - Kafka Connect: Confluent 5.2.1
+  - Kafka Connect: Confluent 5.2.2
   - Kafka Connect UI: 0.9.4
-  - KSQL Server: Confluent 5.2.1
+  - KSQL Server: Confluent 5.2.2
   - Zoonavigator: 0.5.1
 
 # Requirements
@@ -147,7 +147,7 @@ A: yes. Say you want to change `zoo1` port to `12181` (only relevant lines are s
 A: yes. Say you want to change `kafka1` port to `12345` (only relevant lines are shown). Note only `LISTENER_DOCKER_EXTERNAL` changes:
 ```
   kafka1:
-    image: confluentinc/cp-kafka:5.2.1
+    image: confluentinc/cp-kafka:5.2.2
     hostname: kafka1
     ports:
       - "12345:12345"

--- a/full-stack.yml
+++ b/full-stack.yml
@@ -17,7 +17,7 @@ services:
 
 
   kafka1:
-    image: confluentinc/cp-kafka:5.2.1
+    image: confluentinc/cp-kafka:5.2.2
     hostname: kafka1
     ports:
       - "9092:9092"
@@ -35,7 +35,7 @@ services:
       - zoo1
 
   kafka-schema-registry:
-    image: confluentinc/cp-schema-registry:5.2.1
+    image: confluentinc/cp-schema-registry:5.2.2
     hostname: kafka-schema-registry
     ports:
       - "8081:8081"
@@ -59,7 +59,7 @@ services:
       - kafka-schema-registry
 
   kafka-rest-proxy:
-    image: confluentinc/cp-kafka-rest:5.2.1
+    image: confluentinc/cp-kafka-rest:5.2.2
     hostname: kafka-rest-proxy
     ports:
       - "8082:8082"
@@ -89,7 +89,7 @@ services:
       - kafka-rest-proxy
 
   kafka-connect:
-    image: confluentinc/cp-kafka-connect:5.2.1
+    image: confluentinc/cp-kafka-connect:5.2.2
     hostname: kafka-connect
     ports:
       - "8083:8083"
@@ -133,7 +133,7 @@ services:
       - kafka-connect
 
   ksql-server:
-    image: confluentinc/cp-ksql-server:5.2.1
+    image: confluentinc/cp-ksql-server:5.2.2
     hostname: ksql-server
     ports:
       - "8088:8088"

--- a/zk-multiple-kafka-multiple.yml
+++ b/zk-multiple-kafka-multiple.yml
@@ -42,7 +42,7 @@ services:
 
 
   kafka1:
-    image: confluentinc/cp-kafka:5.2.1
+    image: confluentinc/cp-kafka:5.2.2
     hostname: kafka1
     ports:
       - "9092:9092"
@@ -61,7 +61,7 @@ services:
       - zoo3
 
   kafka2:
-    image: confluentinc/cp-kafka:5.2.1
+    image: confluentinc/cp-kafka:5.2.2
     hostname: kafka2
     ports:
       - "9093:9093"
@@ -80,7 +80,7 @@ services:
       - zoo3
 
   kafka3:
-    image: confluentinc/cp-kafka:5.2.1
+    image: confluentinc/cp-kafka:5.2.2
     hostname: kafka3
     ports:
       - "9094:9094"

--- a/zk-multiple-kafka-single.yml
+++ b/zk-multiple-kafka-single.yml
@@ -42,7 +42,7 @@ services:
 
 
   kafka1:
-    image: confluentinc/cp-kafka:5.2.1
+    image: confluentinc/cp-kafka:5.2.2
     hostname: kafka1
     ports:
       - "9092:9092"

--- a/zk-single-kafka-multiple.yml
+++ b/zk-single-kafka-multiple.yml
@@ -15,7 +15,7 @@ services:
       - ./zk-single-kafka-multiple/zoo1/datalog:/datalog
 
   kafka1:
-    image: confluentinc/cp-kafka:5.2.1
+    image: confluentinc/cp-kafka:5.2.2
     hostname: kafka1
     ports:
       - "9092:9092"
@@ -32,7 +32,7 @@ services:
       - zoo1
 
   kafka2:
-    image: confluentinc/cp-kafka:5.2.1
+    image: confluentinc/cp-kafka:5.2.2
     hostname: kafka2
     ports:
       - "9093:9093"
@@ -50,7 +50,7 @@ services:
 
 
   kafka3:
-    image: confluentinc/cp-kafka:5.2.1
+    image: confluentinc/cp-kafka:5.2.2
     hostname: kafka3
     ports:
       - "9094:9094"

--- a/zk-single-kafka-single.yml
+++ b/zk-single-kafka-single.yml
@@ -15,7 +15,7 @@ services:
       - ./zk-single-kafka-single/zoo1/datalog:/datalog
 
   kafka1:
-    image: confluentinc/cp-kafka:5.2.1
+    image: confluentinc/cp-kafka:5.2.2
     hostname: kafka1
     ports:
       - "9092:9092"


### PR DESCRIPTION
* Kafka 2.2.1 : https://www.apache.org/dist/kafka/2.2.1/RELEASE_NOTES.html 
* Confluent 2.2.1 : https://docs.confluent.io/current/release-notes.html#cp-5-2-2-release-notes